### PR TITLE
Added Project scoring features

### DIFF
--- a/backend/common/middleware/webhook.js
+++ b/backend/common/middleware/webhook.js
@@ -1,0 +1,14 @@
+const { NotFoundError } = require('../errors/errors')
+
+const WebhookMiddleware = {
+    hasWebhookToken: (req, res, next) => {
+        console.log('CHECKING WEBHOOK API TOKEN', req.query.webhook_api_key)
+        if (req.query.webhook_api_key === global.gConfig.WEBHOOK_API_KEY) {
+            next()
+        } else {
+            next(new NotFoundError())
+        }
+    },
+}
+
+module.exports = WebhookMiddleware

--- a/backend/common/services/webhook.js
+++ b/backend/common/services/webhook.js
@@ -1,0 +1,26 @@
+const axios = require('axios')
+const logger = require('../../misc/logger')
+
+const WebhookService = {
+    actionTypes: ['save', 'remove'],
+
+    handleProjectWebhook: (project, action, event) => {
+        if (!event.webhooks || !event.webhooks.length) return
+
+        const webhooks = event.webhooks.filter(
+            hook =>
+                hook.enabled &&
+                hook.action === action &&
+                hook.resource === 'Project'
+        )
+
+        webhooks.forEach(async webhook => {
+            try {
+                await axios.post(webhook.url, project)
+            } catch (e) {
+                logger.error('Error triggering webhook: ', e.message)
+            }
+        })
+    },
+}
+module.exports = WebhookService

--- a/backend/migrations/01-remove-project-unique-index.js
+++ b/backend/migrations/01-remove-project-unique-index.js
@@ -1,0 +1,60 @@
+/** Change the way registration questions are stored in the Event model.
+ *  Previously events had a rather strange UserDetailsConfig object for defining
+ *  which questions to ask in the registration form. This script makes the following
+ *  change to the event model:
+ *
+ *  Before:
+ *  {
+ *    userDetailsConfig: {
+ *      phoneNumber: {
+ *          enabled: true,
+ *          required: true,
+ *          editable: true
+ *      },
+ *      countryOfResidence: {
+ *          enabled: true,
+ *          required: false,
+ *          editable: true
+ *      },
+ *      ...(all other fields here)
+ *    }
+ *  }
+ *
+ *  After:
+ *  {
+ *    registrationConfig: {
+ *      optionalFields: ['countryOfResidence'],
+ *      requiredFields: ['phoneNumber'],
+ *    }
+ *  }
+ *
+ *  In addition, the "editable" field which was used just for disallowing
+ *  removing firstName, lastName, email from the registration questions, is
+ *  replaced with just hardcoding this condition in code rather than in the
+ *  event model.
+ */
+
+const mongoose = require('mongoose')
+const Promise = require('bluebird')
+const logger = require('../misc/logger')
+
+module.exports = {
+    index: 1,
+    name: '01-remove-project-unique-index',
+    description: 'Remove unique team and event index from Project schema',
+    run: async () => {
+        const indexes = await mongoose.model('Project').listIndexes()
+        const indexToDelete = indexes.find(
+            index => index.name === 'event_1_team_1'
+        )
+        if (indexToDelete) {
+            await mongoose
+                .model('Project')
+                .collection.dropIndex(indexToDelete.name)
+            logger.info(`Unique index dropped`)
+        } else {
+            logger.info(`-> No indexes to deletee`)
+        }
+        return Promise.resolve()
+    },
+}

--- a/backend/migrations/01-remove-project-unique-index.js
+++ b/backend/migrations/01-remove-project-unique-index.js
@@ -1,39 +1,3 @@
-/** Change the way registration questions are stored in the Event model.
- *  Previously events had a rather strange UserDetailsConfig object for defining
- *  which questions to ask in the registration form. This script makes the following
- *  change to the event model:
- *
- *  Before:
- *  {
- *    userDetailsConfig: {
- *      phoneNumber: {
- *          enabled: true,
- *          required: true,
- *          editable: true
- *      },
- *      countryOfResidence: {
- *          enabled: true,
- *          required: false,
- *          editable: true
- *      },
- *      ...(all other fields here)
- *    }
- *  }
- *
- *  After:
- *  {
- *    registrationConfig: {
- *      optionalFields: ['countryOfResidence'],
- *      requiredFields: ['phoneNumber'],
- *    }
- *  }
- *
- *  In addition, the "editable" field which was used just for disallowing
- *  removing firstName, lastName, email from the registration questions, is
- *  replaced with just hardcoding this condition in code rather than in the
- *  event model.
- */
-
 const mongoose = require('mongoose')
 const Promise = require('bluebird')
 const logger = require('../misc/logger')
@@ -53,7 +17,7 @@ module.exports = {
                 .collection.dropIndex(indexToDelete.name)
             logger.info(`Unique index dropped`)
         } else {
-            logger.info(`-> No indexes to deletee`)
+            logger.info(`-> No indexes to delete`)
         }
         return Promise.resolve()
     },

--- a/backend/migrations/index.js
+++ b/backend/migrations/index.js
@@ -2,7 +2,10 @@
 const Promise = require('bluebird')
 const logger = require('../misc/logger')
 
-const migrations = [require('./00-registration-questions')]
+const migrations = [
+    require('./00-registration-questions'),
+    require('./01-remove-project-unique-index'),
+]
 
 const run = async () => {
     logger.info('Running database migrations before startup...')

--- a/backend/misc/config.js
+++ b/backend/misc/config.js
@@ -101,6 +101,10 @@ const settings = {
         required: false,
         value: process.env.SENDGRID_MAILING_LIST_ID || '7150117',
     },
+    WEBHOOK_API_KEY: {
+        required: false,
+        value: process.env.WEBHOOK_API_KEY || 'NotVerySafeWebhookApiKey',
+    },
 }
 
 const buildConfig = () => {

--- a/backend/modules/event/model.js
+++ b/backend/modules/event/model.js
@@ -15,6 +15,7 @@ const UserDetailsConfigSchema = require('@hackjunction/shared/schemas/UserDetail
 const EventTagSchema = require('@hackjunction/shared/schemas/EventTag')
 const RegistrationConfigSchema = require('@hackjunction/shared/schemas/RegistrationConfig')
 const AddressSchema = require('@hackjunction/shared/schemas/Address')
+const WebhookSchema = require('@hackjunction/shared/schemas/Webhook')
 const allowPublishPlugin = require('../../common/plugins/allowPublish')
 const updateAllowedPlugin = require('../../common/plugins/updateAllowed')
 const uploadHelper = require('../../modules/upload/helper')
@@ -168,6 +169,10 @@ const EventSchema = new mongoose.Schema({
     },
     tags: {
         type: [EventTagSchema.mongoose],
+        default: [],
+    },
+    webhooks: {
+        type: [WebhookSchema.mongoose],
         default: [],
     },
     /** System metadata */

--- a/backend/modules/event/model.js
+++ b/backend/modules/event/model.js
@@ -130,6 +130,10 @@ const EventSchema = new mongoose.Schema({
             'is required if challenges are enabled',
         ],
     },
+    allowProjectSubmissionsPerChallenge: {
+        type: Boolean,
+        default: false,
+    },
     travelGrantConfig: {
         type: TravelGrantConfigSchema.mongoose,
         default: TravelGrantConfigSchema.mongoose,

--- a/backend/modules/project/controller.js
+++ b/backend/modules/project/controller.js
@@ -54,10 +54,11 @@ controller.createProjectForEventAndTeam = async (event, team, data) => {
 controller.updateProjectForEventAndTeam = async (event, team, data) => {
     const schema = yup.object().shape(ProjectSchema(event))
     const validatedData = await schema.validate(data, { stripUnknown: true })
-    const project = await controller.getProjectsByEventAndTeam(
+    const projects = await controller.getProjectsByEventAndTeam(
         event._id,
         team._id
     )
+    const project = projects.find(p => p._id.toString() === data._id)
     project.set(validatedData)
 
     return project.save()

--- a/backend/modules/project/controller.js
+++ b/backend/modules/project/controller.js
@@ -32,8 +32,8 @@ controller.getAllProjectsByEvent = eventId => {
     })
 }
 
-controller.getProjectByEventAndTeam = (eventId, teamId) => {
-    return Project.findOne({
+controller.getProjectsByEventAndTeam = (eventId, teamId) => {
+    return Project.find({
         event: eventId,
         team: teamId,
     })
@@ -54,7 +54,7 @@ controller.createProjectForEventAndTeam = async (event, team, data) => {
 controller.updateProjectForEventAndTeam = async (event, team, data) => {
     const schema = yup.object().shape(ProjectSchema(event))
     const validatedData = await schema.validate(data, { stripUnknown: true })
-    const project = await controller.getProjectByEventAndTeam(
+    const project = await controller.getProjectsByEventAndTeam(
         event._id,
         team._id
     )

--- a/backend/modules/project/model.js
+++ b/backend/modules/project/model.js
@@ -4,6 +4,7 @@ const { ReviewingMethods } = require('@hackjunction/shared')
 const CloudinaryImageSchema = require('@hackjunction/shared/schemas/CloudinaryImage')
 const AchievementSchema = require('../../common/schemas/Achievement')
 const GavelController = require('../reviewing/gavel/controller')
+const WebhookService = require('../../common/services/webhook')
 
 const ProjectSchema = new mongoose.Schema({
     event: {
@@ -79,22 +80,18 @@ ProjectSchema.methods.getPreview = function() {
 }
 
 ProjectSchema.post('save', async function(doc, next) {
-    mongoose
-        .model('Event')
-        .findById(this.event)
-        .then(event => {
-            switch (event.reviewMethod) {
-                /** If using Gavel peer review, make sure a GavelProject exists for each project, and is updated accordingly */
-                case ReviewingMethods.gavelPeerReview.id: {
-                    GavelController.ensureGavelProject(doc)
-                    break
-                }
-                default: {
-                    /** By default, no action needed */
-                }
-            }
-        })
-
+    const event = await mongoose.model('Event').findById(this.event)
+    switch (event.reviewMethod) {
+        /** If using Gavel peer review, make sure a GavelProject exists for each project, and is updated accordingly */
+        case ReviewingMethods.gavelPeerReview.id: {
+            GavelController.ensureGavelProject(doc)
+            break
+        }
+        default: {
+            /** By default, no action needed */
+        }
+    }
+    WebhookService.handleProjectWebhook(doc, 'save', event)
     next()
 })
 

--- a/backend/modules/project/model.js
+++ b/backend/modules/project/model.js
@@ -58,7 +58,7 @@ const ProjectSchema = new mongoose.Schema({
 ProjectSchema.set('timestamps', true)
 
 /* Only allow a single project per team per event */
-ProjectSchema.index(
+/* ProjectSchema.index(
     {
         event: 1,
         team: 1,
@@ -66,7 +66,7 @@ ProjectSchema.index(
     {
         unique: true,
     }
-)
+) */
 
 /* We'll commonly query projects by track and event, so create a compound index for that */
 ProjectSchema.index({

--- a/backend/modules/project/routes.js
+++ b/backend/modules/project/routes.js
@@ -38,16 +38,16 @@ router
 
 router
     .route('/:slug/team')
-    /** Get the project submitted by a user's team at a given event */
+    /** Get the projects submitted by a user's team at a given event */
     .get(
         hasToken,
         canSubmitProject,
         asyncHandler(async (req, res) => {
-            const project = await ProjectController.getProjectByEventAndTeam(
+            const projects = await ProjectController.getProjectsByEventAndTeam(
                 req.event._id,
                 req.team._id
             )
-            return res.status(200).json(project)
+            return res.status(200).json(projects)
         })
     )
     /** Submit a project for a user's team at a given event */

--- a/backend/modules/project_score/controller.js
+++ b/backend/modules/project_score/controller.js
@@ -27,12 +27,12 @@ controller.updateProjectScore = async (id, updatedProjectScore) => {
     projectScore.message = updatedProjectScore.message
     projectScore.status = updatedProjectScore.status
 
-    await projectScore.update()
+    await projectScore.save()
     return projectScore
 }
 
 controller.getScoresByEventAndTeamId = (eventId, teamId) => {
-    return ProjectScore.find()
+    return ProjectScore.find({ event: eventId })
         .populate({
             path: 'project',
             match: { team: teamId },
@@ -40,7 +40,6 @@ controller.getScoresByEventAndTeamId = (eventId, teamId) => {
         })
         .populate({
             path: 'event',
-            match: { slug: eventId },
         })
 }
 

--- a/backend/modules/project_score/controller.js
+++ b/backend/modules/project_score/controller.js
@@ -32,11 +32,16 @@ controller.updateProjectScore = async (id, updatedProjectScore) => {
 }
 
 controller.getScoresByEventAndTeamId = (eventId, teamId) => {
-    return ProjectScore.find({ event: eventId }).populate({
-        path: 'project',
-        match: { team: teamId },
-        select: '_id',
-    })
+    return ProjectScore.find()
+        .populate({
+            path: 'project',
+            match: { team: teamId },
+            select: '_id',
+        })
+        .populate({
+            path: 'event',
+            match: { slug: eventId },
+        })
 }
 
 controller.getPublicScores = async eventId => {

--- a/backend/modules/project_score/controller.js
+++ b/backend/modules/project_score/controller.js
@@ -1,0 +1,48 @@
+const Event = require('../event/model')
+const Project = require('../project/model')
+const { ProjectScore } = require('./model')
+const { NotFoundError } = require('../../common/errors/errors')
+
+const controller = {}
+
+controller.addProjectScore = async score => {
+    await Project.findById(score.project).orFail(
+        new NotFoundError('The given project does not exist.')
+    )
+    await Event.findById(score.event).orFail(
+        new NotFoundError('The given event does not exist.')
+    )
+
+    const projectScore = new ProjectScore({ ...score })
+    return projectScore.save()
+}
+
+controller.updateProjectScore = async (id, updatedProjectScore) => {
+    const projectScore = await ProjectScore.findById(id).orFail(
+        new NotFoundError('The given ProjectScore does not exist.')
+    )
+
+    projectScore.score = updatedProjectScore.score
+    projectScore.max_score = updatedProjectScore.max_score
+    projectScore.message = updatedProjectScore.message
+    projectScore.status = updatedProjectScore.status
+
+    await projectScore.update()
+    return projectScore
+}
+
+controller.getScoresByEventAndTeamId = (eventId, teamId) => {
+    return ProjectScore.find({ event: eventId }).populate({
+        path: 'project',
+        match: { team: teamId },
+        select: '_id',
+    })
+}
+
+controller.getPublicScores = async eventId => {
+    return ProjectScore.find({ event: eventId })
+        .populate({ path: 'event', select: 'name' })
+        .populate({ path: 'project', select: 'name track challenges' })
+}
+
+module.exports = controller

--- a/backend/modules/project_score/controller.js
+++ b/backend/modules/project_score/controller.js
@@ -43,6 +43,10 @@ controller.getScoresByEventAndTeamId = (eventId, teamId) => {
         })
 }
 
+controller.getScoreByProjectId = projectId => {
+    return ProjectScore.findOne({ project: projectId })
+}
+
 controller.getPublicScores = async eventId => {
     return ProjectScore.find({ event: eventId })
         .populate({ path: 'event', select: 'name' })

--- a/backend/modules/project_score/model.js
+++ b/backend/modules/project_score/model.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose')
+
+const STATUS_TYPES = ['submitted', 'evaluating', 'evaluated']
+const ProjectScoreSchema = new mongoose.Schema(
+    {
+        project: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Project',
+            required: true,
+        },
+        event: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Event',
+            required: true,
+        },
+        status: {
+            type: String,
+            required: true,
+            enum: STATUS_TYPES,
+        },
+        score: {
+            type: Number,
+            required: false,
+        },
+        max_score: {
+            type: Number,
+            required: false,
+        },
+        message: {
+            type: String,
+            required: false,
+        },
+    },
+    { toJSON: { virtuals: true } }
+)
+
+ProjectScoreSchema.set('timestamps', true)
+
+const ProjectScore = mongoose.model('ProjectScore', ProjectScoreSchema)
+
+module.exports = { ProjectScore, ProjectScoreSchema }

--- a/backend/modules/project_score/model.js
+++ b/backend/modules/project_score/model.js
@@ -33,6 +33,15 @@ const ProjectScoreSchema = new mongoose.Schema(
     },
     { toJSON: { virtuals: true } }
 )
+ProjectScoreSchema.index(
+    {
+        project: 1,
+        event: 1,
+    },
+    {
+        unique: true,
+    }
+)
 
 ProjectScoreSchema.set('timestamps', true)
 

--- a/backend/modules/project_score/routes.js
+++ b/backend/modules/project_score/routes.js
@@ -1,0 +1,66 @@
+const express = require('express')
+
+const router = express.Router()
+const asyncHandler = require('express-async-handler')
+const ProjectScoreController = require('./controller')
+
+const { hasToken } = require('../../common/middleware/token')
+const { hasAdminToken } = require('../../common/middleware/admin')
+const { canSubmitProject } = require('../../common/middleware/events')
+
+const addProjectScore = asyncHandler(async (req, res) => {
+    try {
+        const score = await ProjectScoreController.addProjectScore(req.body)
+        return res.status(200).json(score)
+    } catch (e) {
+        console.error(e)
+        return res.status(500).json({
+            message:
+                'Add project score encountered an unknown error. Please check your request and try again.',
+            error: e.message,
+        })
+    }
+})
+
+const updateProjectScore = asyncHandler(async (req, res) => {
+    try {
+        const score = await ProjectScoreController.updateProjectScore(
+            req.params.id,
+            req.body
+        )
+        return res.status(200).json(score)
+    } catch (e) {
+        return res.status(500).json({
+            message:
+                'Update project score encountered an unknown error. Please check your request and try again.',
+            error: e.message,
+        })
+    }
+})
+
+const getScoresByEventAndTeam = asyncHandler(async (req, res) => {
+    const scores = await ProjectScoreController.getScoresByEventAndTeamId(
+        req.event._id,
+        req.team._id
+    )
+    return res.status(200).json(scores)
+})
+
+const getPublicScores = asyncHandler(async (req, res) => {
+    const scores = await ProjectScoreController.getPublicScores(
+        req.params.eventId
+    )
+    return res.status(200).json(scores)
+})
+
+router.post('/', hasAdminToken, addProjectScore)
+router.put('/:id', hasAdminToken, updateProjectScore)
+router.get(
+    '/personal/:eventId',
+    hasToken,
+    canSubmitProject,
+    getScoresByEventAndTeam
+)
+router.get('/event/:eventId', getPublicScores)
+
+module.exports = router

--- a/backend/modules/project_score/routes.js
+++ b/backend/modules/project_score/routes.js
@@ -47,20 +47,18 @@ const getScoresByEventAndTeam = asyncHandler(async (req, res) => {
 })
 
 const getPublicScores = asyncHandler(async (req, res) => {
-    const scores = await ProjectScoreController.getPublicScores(
-        req.params.eventId
-    )
+    const scores = await ProjectScoreController.getPublicScores(req.params.slug)
     return res.status(200).json(scores)
 })
 
 router.post('/', hasWebhookToken, addProjectScore)
 router.put('/:id', hasWebhookToken, updateProjectScore)
 router.get(
-    '/personal/:eventId',
+    '/personal/:slug',
     hasToken,
     canSubmitProject,
     getScoresByEventAndTeam
 )
-router.get('/event/:eventId', getPublicScores)
+router.get('/event/:slug', getPublicScores)
 
 module.exports = router

--- a/backend/modules/project_score/routes.js
+++ b/backend/modules/project_score/routes.js
@@ -5,7 +5,7 @@ const asyncHandler = require('express-async-handler')
 const ProjectScoreController = require('./controller')
 
 const { hasToken } = require('../../common/middleware/token')
-const { hasAdminToken } = require('../../common/middleware/admin')
+const { hasWebhookToken } = require('../../common/middleware/webhook')
 const { canSubmitProject } = require('../../common/middleware/events')
 
 const addProjectScore = asyncHandler(async (req, res) => {
@@ -53,8 +53,8 @@ const getPublicScores = asyncHandler(async (req, res) => {
     return res.status(200).json(scores)
 })
 
-router.post('/', hasAdminToken, addProjectScore)
-router.put('/:id', hasAdminToken, updateProjectScore)
+router.post('/', hasWebhookToken, addProjectScore)
+router.put('/:id', hasWebhookToken, updateProjectScore)
 router.get(
     '/personal/:eventId',
     hasToken,

--- a/backend/modules/project_score/routes.js
+++ b/backend/modules/project_score/routes.js
@@ -6,7 +6,10 @@ const ProjectScoreController = require('./controller')
 
 const { hasToken } = require('../../common/middleware/token')
 const { hasWebhookToken } = require('../../common/middleware/webhook')
-const { canSubmitProject } = require('../../common/middleware/events')
+const {
+    canSubmitProject,
+    isEventOrganiser,
+} = require('../../common/middleware/events')
 
 const addProjectScore = asyncHandler(async (req, res) => {
     try {
@@ -46,6 +49,13 @@ const getScoresByEventAndTeam = asyncHandler(async (req, res) => {
     return res.status(200).json(scores)
 })
 
+const getScoreByProjectId = asyncHandler(async (req, res) => {
+    const score = await ProjectScoreController.getScoreByProjectId(
+        req.params.projectId
+    )
+    return res.status(200).json(score)
+})
+
 const getPublicScores = asyncHandler(async (req, res) => {
     const scores = await ProjectScoreController.getPublicScores(req.params.slug)
     return res.status(200).json(scores)
@@ -60,5 +70,13 @@ router.get(
     getScoresByEventAndTeam
 )
 router.get('/event/:slug', getPublicScores)
+router.get(
+    '/event/:slug/project/:projectId',
+    hasToken,
+    isEventOrganiser,
+    getScoreByProjectId
+)
+router.post('/event/:slug', hasToken, isEventOrganiser, addProjectScore)
+router.put('/event/:slug/:id', hasToken, isEventOrganiser, updateProjectScore)
 
 module.exports = router

--- a/backend/modules/routes.js
+++ b/backend/modules/routes.js
@@ -14,6 +14,7 @@ const projectRouter = require('./project/routes')
 const gavelRouter = require('./reviewing/gavel/routes')
 const winnerVoteRouter = require('./winner-votes/routes')
 const rankingsRouter = require('./rankings/routes')
+const projectScoresRouter = require('./project_score/routes')
 
 module.exports = function(app) {
     app.get('/api', (req, res) => {
@@ -36,6 +37,7 @@ module.exports = function(app) {
     app.use('/api/projects', projectRouter)
     app.use('/api/user-profiles', userProfileRouter)
     app.use('/api/recruitment', recruitmentRouter)
+    app.use('/api/project-scores', projectScoresRouter)
 
     /** Reviewing methods */
     app.use('/api/reviewing/gavel', gavelRouter)

--- a/frontend/src/components/modals/EditProjectModal/index.js
+++ b/frontend/src/components/modals/EditProjectModal/index.js
@@ -1,0 +1,126 @@
+import { useDispatch, useSelector } from 'react-redux'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+
+import * as AuthSelectors from 'redux/auth/selectors'
+import * as OrganiserSelectors from 'redux/organiser/selectors'
+import * as OrganiserActions from 'redux/organiser/actions'
+import * as SnackbarActions from 'redux/snackbar/actions'
+import {
+    Dialog,
+    List,
+    ListItem,
+    ListItemText,
+    ExpansionPanel,
+    ExpansionPanelSummary,
+    Typography,
+    ExpansionPanelDetails,
+    Box,
+} from '@material-ui/core'
+import PageWrapper from 'components/layouts/PageWrapper'
+import CenteredContainer from 'components/generic/CenteredContainer'
+import PageHeader from 'components/generic/PageHeader'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+
+import TeamsTable from 'components/tables/TeamsTable'
+
+export default ({ project, onClose = () => {}, onEdited = () => {} }) => {
+    const dispatch = useDispatch()
+    const idToken = useSelector(AuthSelectors.getIdToken)
+    const event = useSelector(OrganiserSelectors.event)
+    const teams = useSelector(OrganiserSelectors.teams)
+    const { slug } = event
+
+    const team = useMemo(() => {
+        if (teams && project) {
+            return [teams.find(team => team._id === project.team)]
+        }
+        return []
+    }, [project, teams])
+
+    console.log('team', [team])
+    return (
+        <Dialog open={!!project} onClose={onClose} maxWidth="md" fullWidth>
+            <PageWrapper loading={!project}>
+                {project && (
+                    <Box p={1}>
+                        <CenteredContainer>
+                            <PageHeader
+                                heading={project.name}
+                                subheading={project.track}
+                            />
+                            <ExpansionPanel>
+                                <ExpansionPanelSummary
+                                    expandIcon={<ExpandMoreIcon />}
+                                    aria-controls="panel1a-content"
+                                    id="panel1a-header"
+                                >
+                                    <Typography>Project Details</Typography>
+                                </ExpansionPanelSummary>
+                                <ExpansionPanelDetails>
+                                    <List>
+                                        <ListItem>
+                                            <ListItemText
+                                                primary="Name"
+                                                secondary={project.name}
+                                            ></ListItemText>
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemText
+                                                primary="Punchline"
+                                                secondary={project.punchline}
+                                            ></ListItemText>
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemText
+                                                primary="Description"
+                                                secondary={project.description}
+                                            ></ListItemText>
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemText
+                                                primary="Track"
+                                                secondary={project.track}
+                                            ></ListItemText>
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemText
+                                                primary="Challenge"
+                                                secondary={project.challenges.join(
+                                                    ', '
+                                                )}
+                                            ></ListItemText>
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemText
+                                                primary="Demo URL or Coupon code"
+                                                secondary={project.demo}
+                                            ></ListItemText>
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemText
+                                                primary="Source code"
+                                                secondary={project.source}
+                                            ></ListItemText>
+                                        </ListItem>
+                                    </List>
+                                </ExpansionPanelDetails>
+                            </ExpansionPanel>
+                            <ExpansionPanel>
+                                <ExpansionPanelSummary
+                                    expandIcon={<ExpandMoreIcon />}
+                                    aria-controls="panel2a-content"
+                                    id="panel2a-header"
+                                >
+                                    <Typography>Team members</Typography>
+                                </ExpansionPanelSummary>
+                                <ExpansionPanelDetails>
+                                    <TeamsTable teams={team} loading={!team} />
+                                </ExpansionPanelDetails>
+                            </ExpansionPanel>
+                        </CenteredContainer>
+                    </Box>
+                )}
+            </PageWrapper>
+        </Dialog>
+    )
+}

--- a/frontend/src/components/modals/EditProjectModal/index.js
+++ b/frontend/src/components/modals/EditProjectModal/index.js
@@ -15,6 +15,11 @@ import {
     Typography,
     ExpansionPanelDetails,
     Box,
+    TextField,
+    InputLabel,
+    FormControl,
+    Select,
+    MenuItem,
 } from '@material-ui/core'
 import PageWrapper from 'components/layouts/PageWrapper'
 import CenteredContainer from 'components/generic/CenteredContainer'
@@ -22,6 +27,10 @@ import PageHeader from 'components/generic/PageHeader'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 
 import TeamsTable from 'components/tables/TeamsTable'
+import ProjectScoresService from 'services/projectScores'
+import { Formik, Form, Field, ErrorMessage } from 'formik'
+import TextInput from 'components/inputs/TextInput'
+import Button from 'components/generic/Button'
 
 export default ({ project, onClose = () => {}, onEdited = () => {} }) => {
     const dispatch = useDispatch()
@@ -30,6 +39,25 @@ export default ({ project, onClose = () => {}, onEdited = () => {} }) => {
     const teams = useSelector(OrganiserSelectors.teams)
     const { slug } = event
 
+    const [projectScore, setProjectScore] = useState({
+        project: '',
+        event: '',
+        status: 'submitted',
+        score: 0,
+        max_score: 10,
+        message: '',
+    })
+    useEffect(() => {
+        if (project && event) {
+            ProjectScoresService.getScoreByEventSlugAndProjectId(
+                idToken,
+                event.slug,
+                project._id
+            ).then(score => {
+                if (score) setProjectScore(score)
+            })
+        }
+    }, [event, idToken, project])
     const team = useMemo(() => {
         if (teams && project) {
             return [teams.find(team => team._id === project.team)]
@@ -37,7 +65,7 @@ export default ({ project, onClose = () => {}, onEdited = () => {} }) => {
         return []
     }, [project, teams])
 
-    console.log('team', [team])
+    console.log('projectScore', { ...projectScore })
     return (
         <Dialog open={!!project} onClose={onClose} maxWidth="md" fullWidth>
             <PageWrapper loading={!project}>
@@ -111,10 +139,155 @@ export default ({ project, onClose = () => {}, onEdited = () => {} }) => {
                                     aria-controls="panel2a-content"
                                     id="panel2a-header"
                                 >
-                                    <Typography>Team members</Typography>
+                                    <Typography>Team Members</Typography>
                                 </ExpansionPanelSummary>
                                 <ExpansionPanelDetails>
-                                    <TeamsTable teams={team} loading={!team} />
+                                    <Box
+                                        display="flex"
+                                        flexDirection="column"
+                                        style={{ width: '100%' }}
+                                    >
+                                        <Typography gutterBottom>
+                                            Click on the team to view members!
+                                        </Typography>
+                                        <TeamsTable
+                                            teams={team}
+                                            loading={!team}
+                                            simplifiedView={true}
+                                        />
+                                    </Box>
+                                </ExpansionPanelDetails>
+                            </ExpansionPanel>
+
+                            <ExpansionPanel>
+                                <ExpansionPanelSummary
+                                    expandIcon={<ExpandMoreIcon />}
+                                    aria-controls="panel3a-content"
+                                    id="panel3a-header"
+                                >
+                                    <Typography>Project Score</Typography>
+                                </ExpansionPanelSummary>
+                                <ExpansionPanelDetails>
+                                    <Formik
+                                        initialValues={{
+                                            ...projectScore,
+                                        }}
+                                        enableReinitialize={true}
+                                        onSubmit={async (
+                                            values,
+                                            { setSubmitting }
+                                        ) => {
+                                            values.project = project._id
+                                            values.event = event._id
+                                            try {
+                                                if (projectScore._id) {
+                                                    await ProjectScoresService.updateScoreByEventSlug(
+                                                        idToken,
+                                                        event.slug,
+                                                        values
+                                                    )
+                                                } else {
+                                                    await ProjectScoresService.addScoreByEventSlug(
+                                                        idToken,
+                                                        event.slug,
+                                                        values
+                                                    )
+                                                }
+                                                dispatch(
+                                                    SnackbarActions.success(
+                                                        'Score saved successfully.'
+                                                    )
+                                                )
+                                            } catch (e) {
+                                                dispatch(
+                                                    SnackbarActions.error(
+                                                        `Score could not be saved. Error: ${e.message}`
+                                                    )
+                                                )
+                                            } finally {
+                                                setSubmitting(false)
+                                            }
+                                        }}
+                                    >
+                                        {({ isSubmitting }) => (
+                                            <Form>
+                                                <Field name="status">
+                                                    {({ field }) => (
+                                                        <FormControl fullWidth>
+                                                            <InputLabel>
+                                                                Status
+                                                            </InputLabel>
+                                                            <Select {...field}>
+                                                                <MenuItem value="submitted">
+                                                                    Submitted
+                                                                </MenuItem>
+                                                                <MenuItem value="evaluating">
+                                                                    Evaluating
+                                                                </MenuItem>
+                                                                <MenuItem value="evaluated">
+                                                                    Evaluated
+                                                                </MenuItem>
+                                                            </Select>
+                                                        </FormControl>
+                                                    )}
+                                                </Field>
+                                                <ErrorMessage
+                                                    name="status"
+                                                    component="div"
+                                                />
+                                                <Field name="score">
+                                                    {({ field }) => (
+                                                        <TextField
+                                                            fullWidth
+                                                            label="Score"
+                                                            type="number"
+                                                            {...field}
+                                                        />
+                                                    )}
+                                                </Field>
+                                                <ErrorMessage
+                                                    name="score"
+                                                    component="div"
+                                                />
+                                                <Field name="max_score">
+                                                    {({ field }) => (
+                                                        <TextField
+                                                            fullWidth
+                                                            type="number"
+                                                            label="Maximum Score"
+                                                            {...field}
+                                                        />
+                                                    )}
+                                                </Field>
+                                                <ErrorMessage
+                                                    name="max_score"
+                                                    component="div"
+                                                />
+                                                <Field name="message">
+                                                    {({ field }) => (
+                                                        <TextField
+                                                            fullWidth
+                                                            label="Message"
+                                                            {...field}
+                                                        />
+                                                    )}
+                                                </Field>
+                                                <ErrorMessage
+                                                    name="message"
+                                                    component="div"
+                                                />
+                                                <Box p={2} />
+                                                <Button
+                                                    color="theme_turquoise"
+                                                    variant="contained"
+                                                    type="submit"
+                                                    disabled={isSubmitting}
+                                                >
+                                                    Save
+                                                </Button>
+                                            </Form>
+                                        )}
+                                    </Formik>
                                 </ExpansionPanelDetails>
                             </ExpansionPanel>
                         </CenteredContainer>

--- a/frontend/src/components/modals/ProjectScoreModal/index.js
+++ b/frontend/src/components/modals/ProjectScoreModal/index.js
@@ -1,18 +1,26 @@
 import React from 'react'
 
-import { Box, Typography } from '@material-ui/core'
+import {
+    Box,
+    Typography,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+} from '@material-ui/core'
 
-import Modal from 'components/generic/Modal'
 import Button from 'components/generic/Button'
 import { useDispatch } from 'react-redux'
+import * as DashboardActions from 'redux/dashboard/actions'
 
 const ProjectScoreModal = ({ open, onClose, score }) => {
     const dispatch = useDispatch()
 
-    const handleRefresh = () => {}
+    const handleRefresh = () => {
+        dispatch(DashboardActions.updateProjectScores(score.event.slug))
+    }
     const NoScoreYet = props => {
         return (
-            <Typography variant="h4">
+            <Typography variant="h6" align="center">
                 You do not have a score for this project yet. Hold tight while
                 our robots do the work!
             </Typography>
@@ -21,11 +29,18 @@ const ProjectScoreModal = ({ open, onClose, score }) => {
     const EvaluatingScore = props => {
         return (
             <>
-                <Typography variant="h4">
-                    Great work. Your project is being evaluated. You can hit
-                    refresh to load-test our servers!
+                <Typography variant="h6" align="center">
+                    Great work so far! Your project is being evaluated right
+                    now.
                 </Typography>
-                <Button onClick="() => handleRefresh">Refresh Score</Button>
+                <Box p={2} />
+                <Button
+                    onClick={() => handleRefresh()}
+                    variant="contained"
+                    color="secondary"
+                >
+                    Refresh Score
+                </Button>
             </>
         )
     }
@@ -33,33 +48,38 @@ const ProjectScoreModal = ({ open, onClose, score }) => {
     const EvaluationSuccessful = props => {
         return (
             <>
-                <Typography variant="h3">
-                    Your result is: <br />
+                <Typography variant="h6" gutterBottom align="center">
+                    Awesome, the result for your project is:
+                </Typography>
+                <Typography variant="h5" gutterBottom>
                     {score.score}/{score.max_score}
                 </Typography>
-                <Typography variant="h4">{score.message}</Typography>
+                <Typography variant="body1">{score.message}</Typography>
             </>
         )
     }
     return (
-        <Modal isOpen={open} handleClose={onClose} size="max">
-            <Box
-                p={5}
-                display="flex"
-                height="100%"
-                flexDirection="column"
-                alignItems="center"
-                justifyContent="center"
-            >
-                {!score && <NoScoreYet />}
-                {(score && score.status) === 'evaluating' && (
-                    <EvaluatingScore />
-                )}
-                {(score && score.status) === 'evaluated' && (
-                    <EvaluationSuccessful />
-                )}
-            </Box>
-        </Modal>
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle>Project Score</DialogTitle>
+            <DialogContent>
+                <Box
+                    p={5}
+                    display="flex"
+                    height="100%"
+                    flexDirection="column"
+                    alignItems="center"
+                    justifyContent="center"
+                >
+                    {!score && <NoScoreYet />}
+                    {score && score.status === 'evaluating' && (
+                        <EvaluatingScore />
+                    )}
+                    {score && score.status === 'evaluated' && (
+                        <EvaluationSuccessful />
+                    )}
+                </Box>
+            </DialogContent>
+        </Dialog>
     )
 }
 

--- a/frontend/src/components/modals/ProjectScoreModal/index.js
+++ b/frontend/src/components/modals/ProjectScoreModal/index.js
@@ -1,0 +1,66 @@
+import React from 'react'
+
+import { Box, Typography } from '@material-ui/core'
+
+import Modal from 'components/generic/Modal'
+import Button from 'components/generic/Button'
+import { useDispatch } from 'react-redux'
+
+const ProjectScoreModal = ({ open, onClose, score }) => {
+    const dispatch = useDispatch()
+
+    const handleRefresh = () => {}
+    const NoScoreYet = props => {
+        return (
+            <Typography variant="h4">
+                You do not have a score for this project yet. Hold tight while
+                our robots do the work!
+            </Typography>
+        )
+    }
+    const EvaluatingScore = props => {
+        return (
+            <>
+                <Typography variant="h4">
+                    Great work. Your project is being evaluated. You can hit
+                    refresh to load-test our servers!
+                </Typography>
+                <Button onClick="() => handleRefresh">Refresh Score</Button>
+            </>
+        )
+    }
+
+    const EvaluationSuccessful = props => {
+        return (
+            <>
+                <Typography variant="h3">
+                    Your result is: <br />
+                    {score.score}/{score.max_score}
+                </Typography>
+                <Typography variant="h4">{score.message}</Typography>
+            </>
+        )
+    }
+    return (
+        <Modal isOpen={open} handleClose={onClose} size="max">
+            <Box
+                p={5}
+                display="flex"
+                height="100%"
+                flexDirection="column"
+                alignItems="center"
+                justifyContent="center"
+            >
+                {!score && <NoScoreYet />}
+                {(score && score.status) === 'evaluating' && (
+                    <EvaluatingScore />
+                )}
+                {(score && score.status) === 'evaluated' && (
+                    <EvaluationSuccessful />
+                )}
+            </Box>
+        </Modal>
+    )
+}
+
+export default ProjectScoreModal

--- a/frontend/src/components/tables/ProjectsTable/index.js
+++ b/frontend/src/components/tables/ProjectsTable/index.js
@@ -1,14 +1,34 @@
-import React, { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import React, { useMemo, useCallback, useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
 
 import * as OrganiserSelectors from 'redux/organiser/selectors'
 
 import { Table, Filters, Sorters } from 'components/generic/_Table'
 import JobRoleInput from 'components/inputs/JobRoleInput'
+import { push } from 'connected-react-router'
+import { useLocation } from 'react-router-dom'
+import EditProjectModal from 'components/modals/EditProjectModal'
 
 const ProjectsTable = ({ projects }) => {
     const teams = useSelector(OrganiserSelectors.teams)
+    const dispatch = useDispatch()
+    const location = useLocation()
+    const searchParams = new URLSearchParams(location.search)
+    const query = new URLSearchParams(location.search)
+    const hasModal = query.has('modal')
+    const activeModal = query.get('modal')
+
+    const [selectedProject, setSelectedProject] = useState(null)
     // TODO config columsn (table only in physical events)
+    const openSingleEdit = useCallback(row => {
+        setSelectedProject(row.original)
+        /* const search = `?${new URLSearchParams({
+                modal: 'edit',
+                id: row.original.user,
+            }).toString()}`
+            dispatch(push({ search })) */
+    }, [])
+
     const columns = useMemo(() => {
         return [
             {
@@ -54,7 +74,15 @@ const ProjectsTable = ({ projects }) => {
         }
         return project
     })
-    return <Table data={data} columns={columns} />
+    return (
+        <>
+            <EditProjectModal
+                project={selectedProject}
+                onClose={() => setSelectedProject(null)}
+            />
+            <Table data={data} columns={columns} onRowClick={openSingleEdit} />
+        </>
+    )
 }
 
 export default ProjectsTable

--- a/frontend/src/components/tables/TeamsTable/index.js
+++ b/frontend/src/components/tables/TeamsTable/index.js
@@ -11,7 +11,7 @@ import BulkEmailModal from 'components/modals/BulkEmailModal'
 import { Table, Sorters } from 'components/generic/_Table'
 import AttendeeTable from '../AttendeeTable'
 
-export default ({ loading, teams = [] }) => {
+export default ({ loading, teams = [], simplifiedView = false }) => {
     const registrationsMap = useSelector(OrganiserSelectors.registrationsMap)
     const [reviewStatus, setReviewStatus] = useState('any')
     const [completedStatus, setCompletedStatus] = useState('any')
@@ -149,80 +149,91 @@ export default ({ loading, teams = [] }) => {
                 onClose={setBulkEmail}
                 registrationIds={filteredMemberIds}
             />
-            <Grid item xs={12} md={6}>
-                <Paper p={2}>
-                    <Box p={2}>
-                        <Select
-                            value={completedStatus}
-                            onChange={setCompletedStatus}
-                            label="Completed status"
-                            options={[
-                                {
-                                    value: 'any',
-                                    label: 'Any',
-                                },
-                                {
-                                    value: 'completed',
-                                    label: 'Completed',
-                                },
-                                {
-                                    value: 'not-completed',
-                                    label: 'Not completed',
-                                },
-                            ]}
-                        />
-                    </Box>
-                </Paper>
-            </Grid>
-            <Grid item xs={12} md={6}>
-                <Paper>
-                    <Box p={2}>
-                        <Select
-                            value={reviewStatus}
-                            onChange={setReviewStatus}
-                            label="Review status"
-                            options={[
-                                {
-                                    value: 'any',
-                                    label: 'Any',
-                                },
-                                {
-                                    value: 'fully-reviewed',
-                                    label: 'Fully reviewed',
-                                },
-                                {
-                                    value: 'not-reviewed',
-                                    label: 'Not fully reviewed',
-                                },
-                            ]}
-                        />
-                    </Box>
-                </Paper>
-            </Grid>
-            <Grid item xs={12}>
-                <Paper>
-                    <Box padding={2} display="flex" flexDirection="column">
-                        <Typography
-                            variant="subtitle1"
-                            paragraph
-                            align="center"
-                        >
-                            Rating between
-                        </Typography>
-                        <Box paddingLeft={2} paddingRight={2}>
-                            <Slider
-                                defaultValue={ratingRange}
-                                onChangeCommitted={handleRatingRangeChange}
-                                valueLabelDisplay="on"
-                                aria-labelledby="range-slider"
-                                min={0}
-                                max={5}
-                                step={0.1}
-                            />
-                        </Box>
-                    </Box>
-                </Paper>
-            </Grid>
+            {!simplifiedView && (
+                <>
+                    <Grid item xs={12} md={6}>
+                        <Paper p={2}>
+                            <Box p={2}>
+                                <Select
+                                    value={completedStatus}
+                                    onChange={setCompletedStatus}
+                                    label="Completed status"
+                                    options={[
+                                        {
+                                            value: 'any',
+                                            label: 'Any',
+                                        },
+                                        {
+                                            value: 'completed',
+                                            label: 'Completed',
+                                        },
+                                        {
+                                            value: 'not-completed',
+                                            label: 'Not completed',
+                                        },
+                                    ]}
+                                />
+                            </Box>
+                        </Paper>
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <Paper>
+                            <Box p={2}>
+                                <Select
+                                    value={reviewStatus}
+                                    onChange={setReviewStatus}
+                                    label="Review status"
+                                    options={[
+                                        {
+                                            value: 'any',
+                                            label: 'Any',
+                                        },
+                                        {
+                                            value: 'fully-reviewed',
+                                            label: 'Fully reviewed',
+                                        },
+                                        {
+                                            value: 'not-reviewed',
+                                            label: 'Not fully reviewed',
+                                        },
+                                    ]}
+                                />
+                            </Box>
+                        </Paper>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Paper>
+                            <Box
+                                padding={2}
+                                display="flex"
+                                flexDirection="column"
+                            >
+                                <Typography
+                                    variant="subtitle1"
+                                    paragraph
+                                    align="center"
+                                >
+                                    Rating between
+                                </Typography>
+                                <Box paddingLeft={2} paddingRight={2}>
+                                    <Slider
+                                        defaultValue={ratingRange}
+                                        onChangeCommitted={
+                                            handleRatingRangeChange
+                                        }
+                                        valueLabelDisplay="on"
+                                        aria-labelledby="range-slider"
+                                        min={0}
+                                        max={5}
+                                        step={0.1}
+                                    />
+                                </Box>
+                            </Box>
+                        </Paper>
+                    </Grid>
+                </>
+            )}
+
             <Grid item xs={12}>
                 <Table
                     data={teamsFiltered}

--- a/frontend/src/pages/_dashboard/:slug/default/Blocks/CertificateBlock.js
+++ b/frontend/src/pages/_dashboard/:slug/default/Blocks/CertificateBlock.js
@@ -20,9 +20,9 @@ export default () => {
     const event = useSelector(DashboardSelectors.event)
     const registration = useSelector(DashboardSelectors.registration)
     const userProfile = useSelector(UserSelectors.userProfile)
-    const project = useSelector(DashboardSelectors.project)
+    const project = useSelector(DashboardSelectors.projects)
     const eventLoading = useSelector(DashboardSelectors.eventLoading)
-    const projectLoading = useSelector(DashboardSelectors.projectLoading)
+    const projectLoading = useSelector(DashboardSelectors.projectsLoading)
 
     if (!EventHelpers.isEventOver(event, moment)) return null
     if (registration?.status !== RegistrationStatuses.asObject.checkedIn.id)

--- a/frontend/src/pages/_dashboard/:slug/default/Blocks/ProjectBlock.js
+++ b/frontend/src/pages/_dashboard/:slug/default/Blocks/ProjectBlock.js
@@ -16,8 +16,8 @@ export default () => {
     const dispatch = useDispatch()
     const event = useSelector(DashboardSelectors.event)
     const registration = useSelector(DashboardSelectors.registration)
-    const project = useSelector(DashboardSelectors.project)
-    const projectLoading = useSelector(DashboardSelectors.projectLoading)
+    const project = useSelector(DashboardSelectors.projects)
+    const projectLoading = useSelector(DashboardSelectors.projectsLoading)
     const isSubmissionsUpcoming = useSelector(
         DashboardSelectors.isSubmissionsUpcoming
     )

--- a/frontend/src/pages/_dashboard/:slug/index.js
+++ b/frontend/src/pages/_dashboard/:slug/index.js
@@ -70,7 +70,7 @@ export default () => {
 
     /** Update project when team changes */
     useEffect(() => {
-        dispatch(DashboardActions.updateProject(slug))
+        dispatch(DashboardActions.updateProjects(slug))
     }, [slug, team, dispatch])
 
     return (

--- a/frontend/src/pages/_dashboard/:slug/index.js
+++ b/frontend/src/pages/_dashboard/:slug/index.js
@@ -71,6 +71,7 @@ export default () => {
     /** Update project when team changes */
     useEffect(() => {
         dispatch(DashboardActions.updateProjects(slug))
+        dispatch(DashboardActions.updateProjectScores(slug))
     }, [slug, team, dispatch])
 
     return (

--- a/frontend/src/pages/_dashboard/:slug/project/ProjectsList.js
+++ b/frontend/src/pages/_dashboard/:slug/project/ProjectsList.js
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Paper, Typography, Chip, Box, Grid, Button } from '@material-ui/core'
+
+import * as DashboardSelectors from 'redux/dashboard/selectors'
+import * as DashboardActions from 'redux/dashboard/actions'
+import * as SnackbarActions from 'redux/snackbar/actions'
+
+export default props => {
+    const event = useSelector(DashboardSelectors.event)
+    const projects = useSelector(DashboardSelectors.projects)
+
+    const projectSelectedCallback = props.projectSelectedCallback
+
+    const [
+        challengeAndTrackSlugState,
+        setChallengeAndTrackSlugState,
+    ] = useState({})
+
+    useEffect(() => {
+        let challengeAndTrackSlugToNameMap = {}
+        if (event && event.challenges) {
+            event.challenges.forEach(challenge => {
+                challengeAndTrackSlugToNameMap[challenge.slug] = challenge.name
+            })
+        }
+        if (event && event.tracks) {
+            event.tracks.forEach(
+                track =>
+                    (challengeAndTrackSlugToNameMap[track.slug] = track.name)
+            )
+        }
+        setChallengeAndTrackSlugState(challengeAndTrackSlugToNameMap)
+    }, [event])
+
+    const ProjectCard = props => {
+        const project = props.project
+        return (
+            <Grid item xs={12} md={6}>
+                <Paper elevation={1}>
+                    <Box p={2}>
+                        <Typography variant="h4" gutterBottom>
+                            {project.name}
+                        </Typography>
+
+                        <Box m={1} mb={2}>
+                            {project.track && (
+                                <Chip
+                                    color="primary"
+                                    label={
+                                        challengeAndTrackSlugState[
+                                            project.track
+                                        ]
+                                    }
+                                    style={{ marginRight: '6px' }}
+                                ></Chip>
+                            )}
+                            {project.challenges &&
+                                project.challenges.map(challenge => (
+                                    <Chip
+                                        label={
+                                            challengeAndTrackSlugState[
+                                                challenge
+                                            ]
+                                        }
+                                        style={{ marginRight: '6px' }}
+                                        key={challenge}
+                                    />
+                                ))}
+                        </Box>
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={() => projectSelectedCallback(project._id)}
+                        >
+                            Edit submission
+                        </Button>
+                    </Box>
+                </Paper>
+            </Grid>
+        )
+    }
+    return (
+        <Grid container spacing={1}>
+            {projects &&
+                projects.map(project => (
+                    <ProjectCard key={project._id} project={project} />
+                ))}
+            <Grid item xs={12} md={6}>
+                <Paper elevation={3}>
+                    <Box
+                        p={4}
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                        flexDirection="column"
+                    >
+                        <Typography variant="body1" align="center" gutterBottom>
+                            This event allows submissions to multiple
+                            challenges! Add a new one now!
+                        </Typography>
+                        <Box p={1} />
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={() => projectSelectedCallback(null)}
+                        >
+                            Add submission
+                        </Button>
+                    </Box>
+                </Paper>
+            </Grid>
+        </Grid>
+    )
+}

--- a/frontend/src/pages/_dashboard/:slug/project/ProjectsList.js
+++ b/frontend/src/pages/_dashboard/:slug/project/ProjectsList.js
@@ -1,16 +1,23 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Paper, Typography, Chip, Box, Grid, Button } from '@material-ui/core'
+import { Paper, Typography, Chip, Box, Grid } from '@material-ui/core'
 
 import * as DashboardSelectors from 'redux/dashboard/selectors'
 import * as DashboardActions from 'redux/dashboard/actions'
 import * as SnackbarActions from 'redux/snackbar/actions'
 
+import ProjectScoreModal from 'components/modals/ProjectScoreModal'
+import Button from 'components/generic/Button'
+
 export default props => {
     const event = useSelector(DashboardSelectors.event)
     const projects = useSelector(DashboardSelectors.projects)
+    const projectScores = useSelector(DashboardSelectors.projectScores)
 
     const projectSelectedCallback = props.projectSelectedCallback
+
+    const [selectedProjectScore, setSelectedProjectStore] = useState(null)
+    const [projectScoreModalOpen, setProjectScoreModalOpen] = useState(false)
 
     const [
         challengeAndTrackSlugState,
@@ -32,6 +39,22 @@ export default props => {
         }
         setChallengeAndTrackSlugState(challengeAndTrackSlugToNameMap)
     }, [event])
+
+    useEffect(() => {
+        if (projectScoreModalOpen) {
+            setSelectedProjectStore(
+                projectScores.find(s => s._id === selectedProjectScore._id)
+            )
+        }
+    }, [projectScoreModalOpen, projectScores, selectedProjectScore])
+
+    const showProjectScore = project => {
+        const score = projectScores.find(
+            score => score.project._id === project._id
+        )
+        setSelectedProjectStore(score)
+        setProjectScoreModalOpen(true)
+    }
 
     // Checks whether there are more unique challenges that the competitor has not submitted
     // a solution to yet.
@@ -67,7 +90,7 @@ export default props => {
                                             project.track
                                         ]
                                     }
-                                    style={{ marginRight: '6px' }}
+                                    style={{ margin: '3px' }}
                                 ></Chip>
                             )}
                             {project.challenges &&
@@ -78,17 +101,25 @@ export default props => {
                                                 challenge
                                             ]
                                         }
-                                        style={{ marginRight: '6px' }}
+                                        style={{ margin: '3px' }}
                                         key={challenge}
                                     />
                                 ))}
                         </Box>
                         <Button
                             variant="contained"
-                            color="primary"
+                            color="theme_turquoise"
                             onClick={() => projectSelectedCallback(project._id)}
+                            style={{ marginRight: '6px' }}
                         >
-                            Edit submission
+                            Edit Submission
+                        </Button>
+                        <Button
+                            variant="contained"
+                            color="theme_orange"
+                            onClick={() => showProjectScore(project)}
+                        >
+                            View Score
                         </Button>
                     </Box>
                 </Paper>
@@ -131,6 +162,12 @@ export default props => {
                     </Paper>
                 </Grid>
             )}
+
+            <ProjectScoreModal
+                score={selectedProjectScore}
+                open={projectScoreModalOpen}
+                onClose={() => setProjectScoreModalOpen(false)}
+            />
         </Grid>
     )
 }

--- a/frontend/src/pages/_dashboard/:slug/project/ProjectsList.js
+++ b/frontend/src/pages/_dashboard/:slug/project/ProjectsList.js
@@ -33,6 +33,21 @@ export default props => {
         setChallengeAndTrackSlugState(challengeAndTrackSlugToNameMap)
     }, [event])
 
+    // Checks whether there are more unique challenges that the competitor has not submitted
+    // a solution to yet.
+    const canAddMoreSubmissions = () => {
+        if (event && event.challenges && projects) {
+            const challengesWithSubmittedProjects = [].concat.apply(
+                [],
+                projects.map(project => project.challenges)
+            )
+            return event.challenges.filter(
+                challenge =>
+                    challengesWithSubmittedProjects.indexOf(challenge.slug) < 0
+            ).length
+        }
+        return false
+    }
     const ProjectCard = props => {
         const project = props.project
         return (
@@ -86,30 +101,36 @@ export default props => {
                 projects.map(project => (
                     <ProjectCard key={project._id} project={project} />
                 ))}
-            <Grid item xs={12} md={6}>
-                <Paper elevation={3}>
-                    <Box
-                        p={4}
-                        display="flex"
-                        alignItems="center"
-                        justifyContent="center"
-                        flexDirection="column"
-                    >
-                        <Typography variant="body1" align="center" gutterBottom>
-                            This event allows submissions to multiple
-                            challenges! Add a new one now!
-                        </Typography>
-                        <Box p={1} />
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={() => projectSelectedCallback(null)}
+            {canAddMoreSubmissions() && (
+                <Grid item xs={12} md={6}>
+                    <Paper elevation={3}>
+                        <Box
+                            p={4}
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                            flexDirection="column"
                         >
-                            Add submission
-                        </Button>
-                    </Box>
-                </Paper>
-            </Grid>
+                            <Typography
+                                variant="body1"
+                                align="center"
+                                gutterBottom
+                            >
+                                This event allows submissions to multiple
+                                challenges! Add a new one now!
+                            </Typography>
+                            <Box p={1} />
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={() => projectSelectedCallback(null)}
+                            >
+                                Add submission
+                            </Button>
+                        </Box>
+                    </Paper>
+                </Grid>
+            )}
         </Grid>
     )
 }

--- a/frontend/src/pages/_dashboard/:slug/project/SubmissionForm.js
+++ b/frontend/src/pages/_dashboard/:slug/project/SubmissionForm.js
@@ -25,8 +25,10 @@ import * as SnackbarActions from 'redux/snackbar/actions'
 export default () => {
     const dispatch = useDispatch()
     const event = useSelector(DashboardSelectors.event)
-    const project = useSelector(DashboardSelectors.project)
-    const projectLoading = useSelector(DashboardSelectors.projectLoading)
+    const projects = useSelector(DashboardSelectors.projects)
+    const projectLoading = useSelector(DashboardSelectors.projectsLoading)
+
+    let project = projects && projects.length ? projects[0] : null || null
 
     const initialValues = {
         sourcePublic: true,

--- a/frontend/src/pages/_dashboard/:slug/project/SubmissionForm.js
+++ b/frontend/src/pages/_dashboard/:slug/project/SubmissionForm.js
@@ -198,7 +198,7 @@ export default props => {
                                 render={({ field, form }) => (
                                     <FormControl
                                         label="Track"
-                                        hint="Choose the track you are participating on. If you've completed multiple challenges from different tracks, choose the one that best matches your project."
+                                        hint="Choose the track you are participating with this project in. If you've completed multiple challenges from different tracks, choose the one that best matches this project."
                                         touched={
                                             form.touched[field.name] ||
                                             formikProps.submitCount > 0
@@ -231,7 +231,7 @@ export default props => {
                                 render={({ field, form }) => (
                                     <FormControl
                                         label="Challenges"
-                                        hint="Which partner challenges do you want to submit your project in? You can choose up to 5."
+                                        hint="Which partner challenges do you want to submit your project in? You can choose up to 5. Note: make sure you read the event guidelines about how many challenges you can set here!"
                                         touched={
                                             form.touched[field.name] ||
                                             formikProps.submitCount > 0
@@ -295,8 +295,8 @@ export default props => {
                             name="demo"
                             render={({ field, form }) => (
                                 <FormControl
-                                    label="Demo"
-                                    hint="Download your presentation video of the project to Vimeo and link it here. Max duration is 2 minutes. (Make sure everyone receiving the link has access to the video.) If you have any materials, such as a presentation deck or a demo, they should be presented in the video."
+                                    label="Demo URL or Coupon Code"
+                                    hint="Add the link of the working version of your project. Depending on the event, this could be a link to an API, a link to file or a presentation. Make sure the link is accessible for humans, as well as machines!"
                                     touched={
                                         form.touched[field.name] ||
                                         formikProps.submitCount > 0
@@ -314,7 +314,7 @@ export default props => {
                                         onBlur={() =>
                                             form.setFieldTouched(field.name)
                                         }
-                                        placeholder="https://..."
+                                        placeholder="https://... or coupon_code"
                                     />
                                 </FormControl>
                             )}

--- a/frontend/src/pages/_dashboard/:slug/project/SubmissionForm.js
+++ b/frontend/src/pages/_dashboard/:slug/project/SubmissionForm.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 
 import * as yup from 'yup'
 import { useSelector, useDispatch } from 'react-redux'
@@ -22,13 +22,23 @@ import * as DashboardActions from 'redux/dashboard/actions'
 import * as SnackbarActions from 'redux/snackbar/actions'
 
 //TODO make the form labels and hints customizable
-export default () => {
+export default props => {
+    const id = props.id
     const dispatch = useDispatch()
     const event = useSelector(DashboardSelectors.event)
     const projects = useSelector(DashboardSelectors.projects)
     const projectLoading = useSelector(DashboardSelectors.projectsLoading)
 
-    let project = projects && projects.length ? projects[0] : null || null
+    const [project, setProject] = useState(null)
+
+    useEffect(() => {
+        if (projects && projects.length && id) {
+            const foundProject = projects.find(p => p._id === id)
+            setProject(foundProject)
+        } else {
+            setProject(null)
+        }
+    }, [id, projects])
 
     const initialValues = {
         sourcePublic: true,

--- a/frontend/src/pages/_dashboard/:slug/project/index.js
+++ b/frontend/src/pages/_dashboard/:slug/project/index.js
@@ -26,18 +26,24 @@ export default () => {
     )
     const projects = useSelector(DashboardSelectors.projects)
 
-    const [selectedProjectId, setSelectedProjectId] = useState(null)
+    const [selectedProjectId, setSelectedProjectId] = useState(undefined)
     const [showSubmissionForm, setShowSubmissionForm] = useState(false)
+    const [showProjectSelector, setShowProjectSelector] = useState(false)
 
     useEffect(() => {
-        if (projects && projects.length === 0) {
-            setShowSubmissionForm(true)
+        if (projects && event) {
+            if (event.allowProjectSubmissionsPerChallenge) {
+                setShowProjectSelector(true)
+            } else {
+                setShowSubmissionForm(true)
+                if (projects.length) handleProjectSelected(projects[0]._id)
+            }
         }
-    }, [projects])
+    }, [projects, event])
 
     const handleProjectSelected = id => {
         setSelectedProjectId(id)
-        setShowSubmissionForm(true)
+        setShowSubmissionForm(id !== undefined)
     }
 
     if (!event || teamLoading) {
@@ -184,14 +190,35 @@ export default () => {
                     />
                 </GradientBox>
                 <Box p={1} />
-                <ProjectsList
-                    projectSelectedCallback={id => handleProjectSelected(id)}
-                />
-                <Box p={1} />
-                <SubmissionForm id={selectedProjectId} />
 
-                {/*  {showSubmissionForm && (
-                )} */}
+                {showProjectSelector && (
+                    <>
+                        {selectedProjectId === undefined && (
+                            <ProjectsList
+                                projectSelectedCallback={id =>
+                                    handleProjectSelected(id)
+                                }
+                            />
+                        )}
+                        {selectedProjectId !== undefined && (
+                            <Box my={2}>
+                                <Button
+                                    color="theme_orange"
+                                    variant="contained"
+                                    onClick={() =>
+                                        handleProjectSelected(undefined)
+                                    }
+                                >
+                                    Back to Projects
+                                </Button>
+                            </Box>
+                        )}
+                    </>
+                )}
+                <Box p={1} />
+                {showSubmissionForm && (
+                    <SubmissionForm id={selectedProjectId} />
+                )}
             </React.Fragment>
         )
     }

--- a/frontend/src/pages/_dashboard/:slug/project/index.js
+++ b/frontend/src/pages/_dashboard/:slug/project/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 
 import moment from 'moment-timezone'
 import { push } from 'connected-react-router'
@@ -11,6 +11,7 @@ import PageHeader from 'components/generic/PageHeader'
 import GradientBox from 'components/generic/GradientBox'
 import Button from 'components/generic/Button'
 import SubmissionForm from './SubmissionForm'
+import ProjectsList from './ProjectsList'
 
 import * as DashboardSelectors from 'redux/dashboard/selectors'
 
@@ -23,6 +24,22 @@ export default () => {
     const isSubmissionsUpcoming = useSelector(
         DashboardSelectors.isSubmissionsUpcoming
     )
+    const projects = useSelector(DashboardSelectors.projects)
+
+    const [selectedProjectId, setSelectedProjectId] = useState(null)
+    const [showSubmissionForm, setShowSubmissionForm] = useState(false)
+
+    useEffect(() => {
+        if (projects && projects.length === 0) {
+            setShowSubmissionForm(true)
+        }
+    }, [projects])
+
+    const handleProjectSelected = id => {
+        setSelectedProjectId(id)
+        setShowSubmissionForm(true)
+    }
+
     if (!event || teamLoading) {
         return <PageWrapper loading />
     }
@@ -167,7 +184,14 @@ export default () => {
                     />
                 </GradientBox>
                 <Box p={1} />
-                <SubmissionForm />
+                <ProjectsList
+                    projectSelectedCallback={id => handleProjectSelected(id)}
+                />
+                <Box p={1} />
+                <SubmissionForm id={selectedProjectId} />
+
+                {/*  {showSubmissionForm && (
+                )} */}
             </React.Fragment>
         )
     }

--- a/frontend/src/pages/_organise/:slug/edit/configuration/index.js
+++ b/frontend/src/pages/_organise/:slug/edit/configuration/index.js
@@ -62,6 +62,26 @@ export default () => {
             </Grid>
             <Grid item xs={12}>
                 <FastField
+                    name="allowProjectSubmissionsPerChallenge"
+                    render={({ field, form }) => (
+                        <FormControl
+                            label="Projects submitted per challenge"
+                            hint="Does this event allow project submissions for each challenge individually?"
+                            error={form.errors[field.name]}
+                            touched={form.touched[field.name]}
+                        >
+                            <BooleanInput
+                                value={field.value}
+                                onChange={value =>
+                                    form.setFieldValue(field.name, value)
+                                }
+                            />
+                        </FormControl>
+                    )}
+                ></FastField>
+            </Grid>
+            <Grid item xs={12}>
+                <FastField
                     name="eventType"
                     render={({ field, form }) => (
                         <FormControl

--- a/frontend/src/pages/_organise/:slug/edit/other/WebhooksForm.js
+++ b/frontend/src/pages/_organise/:slug/edit/other/WebhooksForm.js
@@ -1,0 +1,236 @@
+import React, { useCallback } from 'react'
+
+import { findIndex } from 'lodash-es'
+import DeleteIcon from '@material-ui/icons/Delete'
+import {
+    List,
+    ListItem,
+    ListItemText,
+    ListItemSecondaryAction,
+    IconButton,
+    Divider,
+    Grid,
+    Typography,
+    ListItemIcon,
+    Switch,
+} from '@material-ui/core'
+import CheckIcon from '@material-ui/icons/Check'
+import BlockIcon from '@material-ui/icons/Block'
+
+import Select from 'components/inputs/Select'
+import TextInput from 'components/inputs/TextInput'
+import Tag from 'components/generic/Tag'
+import Button from 'components/generic/Button'
+
+import { makeStyles } from '@material-ui/core/styles'
+import { useFormField } from 'hooks/formHooks'
+
+const ACTIONS = ['save', 'remove']
+
+const RESOURCES = ['Project']
+
+const useStyles = makeStyles(theme => ({
+    errorMessage: {
+        color: theme.palette.error.main,
+    },
+}))
+
+export default ({ value = [], fieldName, setFieldValue }) => {
+    const classes = useStyles()
+    const name = useFormField('', value => {
+        if (!value || value.length === 0) {
+            return 'A webhook name is required'
+        }
+        if (value.length > 30) {
+            return 'A name can be at most 30 characters'
+        }
+        if (findIndex(value, hook => hook.name === value) !== -1) {
+            return `A webhook with the name ${value} already exists`
+        }
+
+        return
+    })
+    const resource = useFormField(undefined, value => {
+        if (!value || value.length === 0) {
+            return 'A resource is required'
+        }
+
+        return
+    })
+    const action = useFormField(undefined, value => {
+        if (!value || value.length === 0) {
+            return 'An action is required'
+        }
+
+        return
+    })
+
+    const url = useFormField('', value => {
+        if (!value || value.length === 0) {
+            return 'A URL is required'
+        }
+
+        return
+    })
+
+    const enabled = useFormField(false)
+
+    const resetForm = useCallback(() => {
+        name.reset()
+        resource.reset()
+        action.reset()
+        url.reset()
+        enabled.reset()
+    }, [action, enabled, name, resource, url])
+
+    const handleAdd = useCallback(() => {
+        const items = [name, resource, action, url, enabled]
+        let passing = true
+        items.forEach(item => {
+            const err = item.validate(item.value)
+            if (err) {
+                item.setError(err)
+                passing = false
+            }
+        })
+
+        if (!passing) {
+            return
+        } else {
+            setFieldValue(
+                fieldName,
+                value.concat({
+                    name: name.value,
+                    resource: resource.value,
+                    action: action.value,
+                    url: url.value,
+                    enabled: enabled.value,
+                })
+            )
+            resetForm()
+        }
+    }, [
+        name,
+        resource,
+        action,
+        url,
+        enabled,
+        setFieldValue,
+        fieldName,
+        value,
+        resetForm,
+    ])
+
+    const handleDelete = useCallback(
+        name => {
+            setFieldValue(
+                fieldName,
+                value.filter(webhook => webhook.name !== name)
+            )
+        },
+        [setFieldValue, fieldName, value]
+    )
+
+    const renderRows = () => {
+        if (!value) return null
+        return value.map((item, index) => [
+            index !== 0 ? <Divider /> : null,
+            <ListItem>
+                <ListItemIcon>
+                    {item.enabled ? <CheckIcon /> : <BlockIcon />}
+                </ListItemIcon>
+                <ListItemText
+                    primary={`${item.name} - On ${item.resource} ${item.action} it will call ${item.url} `}
+                />
+                <ListItemSecondaryAction>
+                    <IconButton
+                        onClick={() => handleDelete(item.name)}
+                        edge="end"
+                        aria-label="comments"
+                    >
+                        <DeleteIcon />
+                    </IconButton>
+                </ListItemSecondaryAction>
+            </ListItem>,
+        ])
+    }
+
+    return (
+        <Grid container spacing={3} alignItems="flex-end">
+            <Grid item xs={12} md={6}>
+                <TextInput
+                    label="Webhook name"
+                    value={name.value}
+                    onChange={name.setValue}
+                />
+                <Typography variant="caption" className={classes.errorMessage}>
+                    {name.error}
+                </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+                <Select
+                    label="Which resource triggers this hook?"
+                    placeholder="Choose resource"
+                    value={resource.value}
+                    onChange={resource.setValue}
+                    options={RESOURCES.map(resource => ({
+                        label: resource,
+                        value: resource,
+                    }))}
+                />
+                <Typography variant="caption" className={classes.errorMessage}>
+                    {resource.error}
+                </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+                <Select
+                    label="Which action triggers this hook?"
+                    placeholder="Choose an action"
+                    value={action.value}
+                    onChange={action.setValue}
+                    options={ACTIONS.map(action => ({
+                        label: action,
+                        value: action,
+                    }))}
+                />
+                <Typography variant="caption" className={classes.errorMessage}>
+                    {action.error}
+                </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+                <TextInput
+                    label="Webhook URL"
+                    value={url.value}
+                    onChange={url.setValue}
+                />
+                <Typography variant="caption" className={classes.errorMessage}>
+                    {url.error}
+                </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+                <Switch
+                    checked={enabled.value}
+                    onChange={(e, value) => enabled.setValue(value)}
+                    color="primary"
+                    name="enabled"
+                />
+                <Typography variant="caption" className={classes.errorMessage}>
+                    {enabled.error}
+                </Typography>
+            </Grid>
+            <Grid item xs={12} md={3}>
+                <Button
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    onClick={handleAdd}
+                >
+                    Add
+                </Button>
+            </Grid>
+            <Grid item xs={12}>
+                <List>{renderRows()}</List>
+            </Grid>
+        </Grid>
+    )
+}

--- a/frontend/src/pages/_organise/:slug/edit/other/index.js
+++ b/frontend/src/pages/_organise/:slug/edit/other/index.js
@@ -4,6 +4,7 @@ import { Grid } from '@material-ui/core'
 import { FastField } from 'formik'
 import FormControl from 'components/inputs/FormControl'
 import EventTagsForm from './EventTagsForm'
+import WebhooksForm from './WebhooksForm'
 
 export default () => {
     return (
@@ -17,6 +18,23 @@ export default () => {
                             hint="Add tags with which you can mark registrations"
                         >
                             <EventTagsForm
+                                value={field.value}
+                                fieldName={field.name}
+                                setFieldValue={form.setFieldValue}
+                            />
+                        </FormControl>
+                    )}
+                />
+            </Grid>
+            <Grid item xs={12}>
+                <FastField
+                    name="webhooks"
+                    render={({ field, form }) => (
+                        <FormControl
+                            label="Webhooks"
+                            hint="Add webhooks that should fire on different events"
+                        >
+                            <WebhooksForm
                                 value={field.value}
                                 fieldName={field.name}
                                 setFieldValue={form.setFieldValue}

--- a/frontend/src/pages/_organise/:slug/projects/by-challenge/index.js
+++ b/frontend/src/pages/_organise/:slug/projects/by-challenge/index.js
@@ -46,7 +46,11 @@ export default () => {
                             ></ListItemText>
                         </ExpansionPanelSummary>
                         <ExpansionPanelDetails>
-                            <Box display="flex" flexDirection="column">
+                            <Box
+                                display="flex"
+                                flexDirection="column"
+                                style={{ width: '100%' }}
+                            >
                                 <Box p={1}>
                                     <ChallengeLink challenge={challenge.slug} />
                                 </Box>

--- a/frontend/src/pages/_organise/:slug/projects/by-track/index.js
+++ b/frontend/src/pages/_organise/:slug/projects/by-track/index.js
@@ -39,7 +39,13 @@ export default () => {
                             ></ListItemText>
                         </ExpansionPanelSummary>
                         <ExpansionPanelDetails>
-                            <ProjectsTable projects={projects} />
+                            <Box
+                                display="flex"
+                                flexDirection="column"
+                                style={{ width: '100%' }}
+                            >
+                                <ProjectsTable projects={projects} />
+                            </Box>
                         </ExpansionPanelDetails>
                     </ExpansionPanel>
                 )

--- a/frontend/src/redux/dashboard/actionTypes.js
+++ b/frontend/src/redux/dashboard/actionTypes.js
@@ -3,6 +3,7 @@ export const UPDATE_REGISTRATION = 'dashboard/UPDATE_REGISTRATION'
 export const UPDATE_TEAM = 'dashboard/UPDATE_TEAM'
 export const UPDATE_PROJECTS = 'dashboard/UPDATE_PROJECTS'
 export const UPDATE_ANNOTATOR = 'dashboard/UPDATE_ANNOTATOR'
+export const UPDATE_PROJECT_SCORES = 'dashboard/UPDATE_PROJECT_SCORES'
 
 export const EDIT_REGISTRATION = 'dashboard/EDIT_REGISTRATION'
 export const EDIT_TEAM = 'dashboard/EDIT_TEAM'

--- a/frontend/src/redux/dashboard/actionTypes.js
+++ b/frontend/src/redux/dashboard/actionTypes.js
@@ -1,7 +1,7 @@
 export const UPDATE_EVENT = 'dashboard/UPDATE_EVENT'
 export const UPDATE_REGISTRATION = 'dashboard/UPDATE_REGISTRATION'
 export const UPDATE_TEAM = 'dashboard/UPDATE_TEAM'
-export const UPDATE_PROJECT = 'dashboard/UPDATE_PROJECT'
+export const UPDATE_PROJECTS = 'dashboard/UPDATE_PROJECTS'
 export const UPDATE_ANNOTATOR = 'dashboard/UPDATE_ANNOTATOR'
 
 export const EDIT_REGISTRATION = 'dashboard/EDIT_REGISTRATION'

--- a/frontend/src/redux/dashboard/actions.js
+++ b/frontend/src/redux/dashboard/actions.js
@@ -233,12 +233,12 @@ export const lockTeam = (slug, code) => async (dispatch, getState) => {
     return team
 }
 
-export const updateProject = slug => async (dispatch, getState) => {
+export const updateProjects = slug => async (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(getState())
 
     dispatch({
-        type: ActionTypes.UPDATE_PROJECT,
-        promise: ProjectsService.getProjectForEventAndTeam(idToken, slug),
+        type: ActionTypes.UPDATE_PROJECTS,
+        promise: ProjectsService.getProjectsForEventAndTeam(idToken, slug),
         meta: {
             onFailure: e => console.log('Error updating dashboard project', e),
         },
@@ -249,7 +249,7 @@ export const createProject = (slug, data) => async (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(getState())
 
     return dispatch({
-        type: ActionTypes.UPDATE_PROJECT,
+        type: ActionTypes.UPDATE_PROJECTS,
         promise: ProjectsService.createProjectForEventAndTeam(
             idToken,
             slug,
@@ -265,7 +265,7 @@ export const editProject = (slug, data) => async (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(getState())
 
     return dispatch({
-        type: ActionTypes.UPDATE_PROJECT,
+        type: ActionTypes.UPDATE_PROJECTS,
         promise: ProjectsService.updateProjectForEventAndTeam(
             idToken,
             slug,

--- a/frontend/src/redux/dashboard/actions.js
+++ b/frontend/src/redux/dashboard/actions.js
@@ -7,6 +7,7 @@ import EventsService from 'services/events'
 import ProjectsService from 'services/projects'
 import RegistrationsService from 'services/registrations'
 import TeamsService from 'services/teams'
+import ProjectScoresService from 'services/projectScores'
 
 import GavelService from 'services/reviewing/gavel'
 
@@ -283,6 +284,19 @@ export const updateAnnotator = slug => async (dispatch, getState) => {
     })
 
     return error
+}
+
+export const updateProjectScores = slug => async (dispatch, getState) => {
+    const idToken = AuthSelectors.getIdToken(getState())
+
+    return dispatch({
+        type: ActionTypes.UPDATE_PROJECT_SCORES,
+        promise: ProjectScoresService.getScoresByEventAndTeam(idToken, slug),
+        meta: {
+            onFailure: e =>
+                console.log('Error updating dashboard project scores', e),
+        },
+    })
 }
 
 export const beginVoting = slug => async (dispatch, getState) => {

--- a/frontend/src/redux/dashboard/actions.js
+++ b/frontend/src/redux/dashboard/actions.js
@@ -236,7 +236,7 @@ export const lockTeam = (slug, code) => async (dispatch, getState) => {
 export const updateProjects = slug => async (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(getState())
 
-    dispatch({
+    return dispatch({
         type: ActionTypes.UPDATE_PROJECTS,
         promise: ProjectsService.getProjectsForEventAndTeam(idToken, slug),
         meta: {
@@ -248,13 +248,10 @@ export const updateProjects = slug => async (dispatch, getState) => {
 export const createProject = (slug, data) => async (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(getState())
 
+    await ProjectsService.createProjectForEventAndTeam(idToken, slug, data)
     return dispatch({
         type: ActionTypes.UPDATE_PROJECTS,
-        promise: ProjectsService.createProjectForEventAndTeam(
-            idToken,
-            slug,
-            data
-        ),
+        promise: ProjectsService.getProjectsForEventAndTeam(idToken, slug),
         meta: {
             onFailure: e => console.log('Error creating dashboard project', e),
         },
@@ -264,13 +261,10 @@ export const createProject = (slug, data) => async (dispatch, getState) => {
 export const editProject = (slug, data) => async (dispatch, getState) => {
     const idToken = AuthSelectors.getIdToken(getState())
 
+    await ProjectsService.updateProjectForEventAndTeam(idToken, slug, data)
     return dispatch({
         type: ActionTypes.UPDATE_PROJECTS,
-        promise: ProjectsService.updateProjectForEventAndTeam(
-            idToken,
-            slug,
-            data
-        ),
+        promise: ProjectsService.getProjectsForEventAndTeam(idToken, slug),
         meta: {
             onFailure: e => console.log('Error editing dashboard project', e),
         },

--- a/frontend/src/redux/dashboard/reducer.js
+++ b/frontend/src/redux/dashboard/reducer.js
@@ -32,6 +32,12 @@ const initialState = {
         error: false,
         updated: 0,
     },
+    project_scores: {
+        data: null,
+        loading: true,
+        error: false,
+        updated: 0,
+    },
 }
 
 const updateEventHandler = buildHandler('event')
@@ -39,6 +45,8 @@ const updateRegistrationHandler = buildHandler('registration')
 const updateTeamHandler = buildHandler('team')
 const updateProjectsHandler = buildHandler('projects', '_id')
 const updateAnnotatorHandler = buildHandler('annotator')
+const updateProjectScoresHandler = buildHandler('project_scores', '_id')
+
 const editRegistration = buildUpdatePath('registration.data')
 const editTeam = buildUpdatePath('team.data')
 const editAnnotator = buildUpdatePath('annotator.data')
@@ -59,6 +67,9 @@ export default function reducer(state = initialState, action) {
         }
         case ActionTypes.UPDATE_ANNOTATOR: {
             return updateAnnotatorHandler(state, action)
+        }
+        case ActionTypes.UPDATE_PROJECT_SCORES: {
+            return updateProjectScoresHandler(state, action)
         }
         case ActionTypes.EDIT_REGISTRATION: {
             return editRegistration(state, action.payload)

--- a/frontend/src/redux/dashboard/reducer.js
+++ b/frontend/src/redux/dashboard/reducer.js
@@ -21,7 +21,7 @@ const initialState = {
         updated: 0,
     },
     projects: {
-        data: [],
+        data: null,
         loading: true,
         error: false,
         updated: 0,

--- a/frontend/src/redux/dashboard/reducer.js
+++ b/frontend/src/redux/dashboard/reducer.js
@@ -33,7 +33,7 @@ const initialState = {
         updated: 0,
     },
     project_scores: {
-        data: null,
+        data: [],
         loading: true,
         error: false,
         updated: 0,
@@ -45,7 +45,7 @@ const updateRegistrationHandler = buildHandler('registration')
 const updateTeamHandler = buildHandler('team')
 const updateProjectsHandler = buildHandler('projects', '_id')
 const updateAnnotatorHandler = buildHandler('annotator')
-const updateProjectScoresHandler = buildHandler('project_scores', '_id')
+const updateProjectScoresHandler = buildHandler('project_scores')
 
 const editRegistration = buildUpdatePath('registration.data')
 const editTeam = buildUpdatePath('team.data')

--- a/frontend/src/redux/dashboard/reducer.js
+++ b/frontend/src/redux/dashboard/reducer.js
@@ -21,7 +21,7 @@ const initialState = {
         updated: 0,
     },
     projects: {
-        data: null,
+        data: [],
         loading: true,
         error: false,
         updated: 0,
@@ -37,7 +37,7 @@ const initialState = {
 const updateEventHandler = buildHandler('event')
 const updateRegistrationHandler = buildHandler('registration')
 const updateTeamHandler = buildHandler('team')
-const updateProjectsHandler = buildHandler('projects')
+const updateProjectsHandler = buildHandler('projects', '_id')
 const updateAnnotatorHandler = buildHandler('annotator')
 const editRegistration = buildUpdatePath('registration.data')
 const editTeam = buildUpdatePath('team.data')

--- a/frontend/src/redux/dashboard/reducer.js
+++ b/frontend/src/redux/dashboard/reducer.js
@@ -20,7 +20,7 @@ const initialState = {
         error: false,
         updated: 0,
     },
-    project: {
+    projects: {
         data: null,
         loading: true,
         error: false,
@@ -37,7 +37,7 @@ const initialState = {
 const updateEventHandler = buildHandler('event')
 const updateRegistrationHandler = buildHandler('registration')
 const updateTeamHandler = buildHandler('team')
-const updateProjectHandler = buildHandler('project')
+const updateProjectsHandler = buildHandler('projects')
 const updateAnnotatorHandler = buildHandler('annotator')
 const editRegistration = buildUpdatePath('registration.data')
 const editTeam = buildUpdatePath('team.data')
@@ -54,8 +54,8 @@ export default function reducer(state = initialState, action) {
         case ActionTypes.UPDATE_TEAM: {
             return updateTeamHandler(state, action)
         }
-        case ActionTypes.UPDATE_PROJECT: {
-            return updateProjectHandler(state, action)
+        case ActionTypes.UPDATE_PROJECTS: {
+            return updateProjectsHandler(state, action)
         }
         case ActionTypes.UPDATE_ANNOTATOR: {
             return updateAnnotatorHandler(state, action)

--- a/frontend/src/redux/dashboard/selectors.js
+++ b/frontend/src/redux/dashboard/selectors.js
@@ -25,10 +25,10 @@ export const teamLoading = state => state.dashboard.team.loading
 export const teamError = state => state.dashboard.team.error
 export const teamUpdated = state => state.dashboard.team.updated
 
-export const project = state => state.dashboard.project.data
-export const projectLoading = state => state.dashboard.project.loading
-export const projectError = state => state.dashboard.project.error
-export const projectUpdated = state => state.dashboard.project.updated
+export const projects = state => state.dashboard.projects.data
+export const projectsLoading = state => state.dashboard.projects.loading
+export const projectsError = state => state.dashboard.projects.error
+export const projectsUpdated = state => state.dashboard.projects.updated
 
 export const annotator = state => state.dashboard.annotator.data
 export const annotatorLoading = state => state.dashboard.annotator.loading

--- a/frontend/src/redux/dashboard/selectors.js
+++ b/frontend/src/redux/dashboard/selectors.js
@@ -35,6 +35,13 @@ export const annotatorLoading = state => state.dashboard.annotator.loading
 export const annotatorError = state => state.dashboard.annotator.error
 export const annotatorUpdated = state => state.dashboard.annotator.updated
 
+export const projectScores = state => state.dashboard.project_scores.data
+export const projectScoresLoading = state =>
+    state.dashboard.project_scores.loading
+export const projectScoresError = state => state.dashboard.project_scores.error
+export const projectScoresUpdated = state =>
+    state.dashboard.project_scores.updated
+
 export const annotatorVoteCount = createSelector(annotator, annotator => {
     if (!annotator) return 0
     return Math.max(annotator.ignore.length - annotator.skipped.length - 1, 0)

--- a/frontend/src/services/projectScores.js
+++ b/frontend/src/services/projectScores.js
@@ -14,4 +14,39 @@ ProjectScoresService.getScoresByEventAndTeam = (idToken, eventSlug) => {
     return _axios.get(`/project-scores/personal/${eventSlug}`, config(idToken))
 }
 
+ProjectScoresService.getScoreByEventSlugAndProjectId = (
+    idToken,
+    eventSlug,
+    projectId
+) => {
+    return _axios.get(
+        `/project-scores/event/${eventSlug}/project/${projectId}`,
+        config(idToken)
+    )
+}
+
+ProjectScoresService.addScoreByEventSlug = (
+    idToken,
+    eventSlug,
+    projectScore
+) => {
+    return _axios.post(
+        `/project-scores/event/${eventSlug}`,
+        projectScore,
+        config(idToken)
+    )
+}
+
+ProjectScoresService.updateScoreByEventSlug = (
+    idToken,
+    eventSlug,
+    projectScore
+) => {
+    return _axios.put(
+        `/project-scores/event/${eventSlug}/${projectScore._id}`,
+        projectScore,
+        config(idToken)
+    )
+}
+
 export default ProjectScoresService

--- a/frontend/src/services/projectScores.js
+++ b/frontend/src/services/projectScores.js
@@ -1,0 +1,17 @@
+import _axios from 'services/axios'
+
+const ProjectScoresService = {}
+
+function config(idToken) {
+    return {
+        headers: {
+            Authorization: `Bearer ${idToken}`,
+        },
+    }
+}
+
+ProjectScoresService.getScoresByEventAndTeam = (idToken, eventSlug) => {
+    return _axios.get(`/project-scores/personal/${eventSlug}`, config(idToken))
+}
+
+export default ProjectScoresService

--- a/frontend/src/services/projects.js
+++ b/frontend/src/services/projects.js
@@ -17,7 +17,7 @@ ProjectsService.getPublicProjectById = projectId => {
     return _axios.get(`/projects/id/${projectId}`)
 }
 
-ProjectsService.getProjectForEventAndTeam = (idToken, eventSlug) => {
+ProjectsService.getProjectsForEventAndTeam = (idToken, eventSlug) => {
     return _axios.get(`/projects/${eventSlug}/team`, config(idToken))
 }
 

--- a/shared/constants/project-schema.js
+++ b/shared/constants/project-schema.js
@@ -31,10 +31,7 @@ const ProjectSchema = {
         .array()
         .of(yup.string())
         .label('Technologies'),
-    demo: yup
-        .string()
-        .url()
-        .label('Demo link'),
+    demo: yup.string().label('Demo link or coupon code'),
     images: yup
         .array()
         .of(

--- a/shared/schemas/Webhook.js
+++ b/shared/schemas/Webhook.js
@@ -1,0 +1,57 @@
+const mongoose = require('mongoose')
+const {
+    GraphQLObjectType,
+    GraphQLString,
+    GraphQLNonNull,
+    GraphQLBoolean,
+} = require('graphql')
+
+// TODO: The Project ref here might be an issue
+const WebhookSchema = new mongoose.Schema({
+    name: {
+        type: String,
+        required: true,
+    },
+    resource: {
+        type: String,
+        required: true,
+    },
+    action: {
+        type: String,
+        required: true,
+    },
+    url: {
+        type: String,
+        required: true,
+    },
+    enabled: {
+        type: Boolean,
+        required: true,
+    },
+})
+
+const WebhookType = new GraphQLObjectType({
+    name: 'Webhook',
+    fields: {
+        name: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        resource: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        action: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        url: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        enabled: {
+            type: GraphQLBoolean,
+        },
+    },
+})
+
+module.exports = {
+    mongoose: WebhookSchema,
+    graphql: WebhookType,
+}

--- a/shared/schemas/index.js
+++ b/shared/schemas/index.js
@@ -23,7 +23,7 @@ const TravelGrantDetails = require('./TravelGrantDetails')
 const UserDetailsConfig = require('./UserDetailsConfig')
 const UserDetailsConfigItem = require('./UserDetailsConfigItem')
 const UserProfileFields = require('./UserProfileFields')
-
+const Webhook = require('./Webhook')
 // const GraphQLSchema = makeExecutableSchema
 
 const SharedSchema = new GraphQLSchema({
@@ -51,6 +51,7 @@ const SharedSchema = new GraphQLSchema({
         UserDetailsConfig.graphql,
         UserDetailsConfigItem.graphql,
         UserProfileFields.graphql,
+        Webhook.graphql,
     ],
 })
 


### PR DESCRIPTION
See: https://docs.google.com/document/d/1dCgKqP1GSQurJTlpu8TDPxogv0be2IHR4PRyXygX3w0/edit#

A very basic Project Details modal on the organiser dashboard: 
![image](https://user-images.githubusercontent.com/17903881/77854936-86bde080-71ed-11ea-985b-e0aaab4f2295.png)
It shows project and team details: 
![image](https://user-images.githubusercontent.com/17903881/77854939-89203a80-71ed-11ea-9481-175cd43da353.png)
And can be used to manually set Project scores
![image](https://user-images.githubusercontent.com/17903881/77854940-8ae9fe00-71ed-11ea-83d8-a5eceff2da6b.png)
If the event allows multiple challenges, the Project submission interface changes to this (otherwise unchanged)
![image](https://user-images.githubusercontent.com/17903881/77854942-8d4c5800-71ed-11ea-8a3c-803eadbb95e1.png)
When adding or editing a submission, a back button appears on the top: 
![image](https://user-images.githubusercontent.com/17903881/77854944-8faeb200-71ed-11ea-8935-e393cf233c0f.png)
Clicking on Show Score will show a waiting screen or the score, if it is available: 
![image](https://user-images.githubusercontent.com/17903881/77854946-92110c00-71ed-11ea-8e51-365721fccd70.png)

Set up webhooks to trigger on certain events: 
![image](https://user-images.githubusercontent.com/17903881/77855331-0c429000-71f0-11ea-8e44-9e0ba2a40095.png)

In addition to the above, new features are: 

- [x] Trigger one or multiple webhooks on Project saves (extensible in the future)
- [x] APIs to create or update ProjectScores from an external service (eg.: scoring system per event)




